### PR TITLE
Fix #35

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,6 +52,10 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-smallrye-fault-tolerance</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
       <artifactId>quarkus-container-image-jib</artifactId>
     </dependency>
     <dependency>

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -9,8 +9,14 @@ quarkus.swagger-ui.always-include=true
 quarkus.http.cors=true
 
 # containers
-
 quarkus.container-image.registry=quay.io
 quarkus.container-image.group=jbosstm
 quarkus.container-image.name=lra-coordinator
 quarkus.container-image.additional-tags=latest
+
+# jandex
+quarkus.index-dependency.microprofile-lra-api.group-id=org.eclipse.microprofile.lra
+quarkus.index-dependency.microprofile-lra-api.artifact-id=microprofile-lra-api
+
+quarkus.index-dependency.lra-service-base.group-id=org.jboss.narayana.rts
+quarkus.index-dependency.lra-service-base.artifact-id=lra-service-base


### PR DESCRIPTION
- Failed to index org.eclipse.microprofile.faulttolerance.Bulkhead: Class does not exist
- Unable to properly register the hierarchy of LRAData