### PR TITLE
Updated to Quarkus 3.19.1 and migrate to new LRA groupId

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-    <quarkus.platform.version>3.18.4</quarkus.platform.version>
+    <quarkus.platform.version>3.19.1</quarkus.platform.version>
     <skipITs>true</skipITs>
     <surefire-plugin.version>3.5.2</surefire-plugin.version>
   </properties>
@@ -37,7 +37,7 @@
   </dependencyManagement>
   <dependencies>
     <dependency>
-      <groupId>org.jboss.narayana.rts</groupId>
+      <groupId>org.jboss.narayana.lra</groupId>
       <artifactId>lra-coordinator-jar</artifactId>
     </dependency>
     <dependency>


### PR DESCRIPTION
Performs necessary migration of LRA groupId that dependabot did/could(?) not anticipate during https://github.com/jbosstm/lra-coordinator-quarkus/pull/168