### PR TITLE
Update to setup-java v4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Set up JDK ${{ matrix.java }}
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v4
         with:
           java-version: ${{ matrix.java }}
           distribution: temurin
@@ -33,7 +33,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: actions/setup-java@v2
+      - uses: actions/setup-java@v4
         with:
           java-version: 17
           distribution: temurin
@@ -65,7 +65,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: actions/setup-java@v2
+      - uses: actions/setup-java@v4
         with:
           java-version: 17
           distribution: temurin

--- a/.github/workflows/image-push.yml
+++ b/.github/workflows/image-push.yml
@@ -27,7 +27,7 @@ jobs:
           set -e
           echo "::set-output name=NARAYANA_OR_QUARKUS_UPGRADE::$narayana_or_quarkus_upgrade"
       - name: Set up JDK
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v4
         with:
           java-version: 17
           distribution: temurin


### PR DESCRIPTION
Without this, I think we see failures like in https://github.com/jbosstm/lra-coordinator-quarkus/actions/runs/14505803573/job/40694922368?pr=178 (I guess for a similar reason to https://github.com/actions/setup-python/issues/1085#issuecomment-2811678831)