### PR TITLE
Use the lra-coordinator-jar latest version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,6 +9,7 @@
     <compiler-plugin.version>3.14.0</compiler-plugin.version>
     <maven.compiler.release>17</maven.compiler.release>
     <narayana.version>7.2.2.Final</narayana.version>
+    <lra.version>1.0.1.Final</lra.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
@@ -39,6 +40,7 @@
     <dependency>
       <groupId>org.jboss.narayana.lra</groupId>
       <artifactId>lra-coordinator-jar</artifactId>
+      <version>${lra.version}</version>
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>


### PR DESCRIPTION
Use the lra-coordinator-jar latest version instead of using the version defined in the quarkus-bom