### PR TITLE
Implement functional native compilation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,5 @@ nb-configuration.xml
 
 # Local environment
 .env
+ObjectStore
+

--- a/pom.xml
+++ b/pom.xml
@@ -44,6 +44,10 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-narayana-jta</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
       <artifactId>quarkus-arc</artifactId>
     </dependency>
     <dependency>

--- a/src/main/resources/reflection-config.json
+++ b/src/main/resources/reflection-config.json
@@ -7,5 +7,41 @@
     "allPublicMethods" : true,
     "allDeclaredFields" : true,
     "allPublicFields" : true
+  },
+  {
+    "name" : "io.narayana.lra.coordinator.internal.LRARecoveryModule",
+    "allDeclaredConstructors" : true,
+    "allPublicConstructors" : true,
+    "allDeclaredMethods" : true,
+    "allPublicMethods" : true,
+    "allDeclaredFields" : true,
+    "allPublicFields" : true
+  },
+  {
+    "name" : "com.arjuna.ats.internal.arjuna.objectstore.ShadowNoFileLockStore",
+    "allDeclaredConstructors" : true,
+    "allPublicConstructors" : true,
+    "allDeclaredMethods" : true,
+    "allPublicMethods" : true,
+    "allDeclaredFields" : true,
+    "allPublicFields" : true
+  },
+  {
+    "name" : "io.narayana.lra.coordinator.domain.model.LRAParticipantRecord",
+    "allDeclaredConstructors" : true,
+    "allPublicConstructors" : true,
+    "allDeclaredMethods" : true,
+    "allPublicMethods" : true,
+    "allDeclaredFields" : true,
+    "allPublicFields" : true
+  },
+  {
+    "name" : "io.narayana.lra.coordinator.domain.model.LRAParentAbstractRecord",
+    "allDeclaredConstructors" : true,
+    "allPublicConstructors" : true,
+    "allDeclaredMethods" : true,
+    "allPublicMethods" : true,
+    "allDeclaredFields" : true,
+    "allPublicFields" : true
   }
 ]


### PR DESCRIPTION
Fixes #221 

However, it brings narayana-jta extension dependency which contains all the native hooks for Arjuna and ObjectStore. We could copy-paste those in this project but I find it unnecessary. I checked, it adds only 2 MB in the built image:

```
quay.io/jbosstm/lra-coordinator                     7.2.2.Final-3.28.2  a9896019f88c  3 minutes ago   450 MB
localhost/test-lra-coordinator                      latest              cac728436f68  12 minutes ago  452 MB
```

But this makes the whole TCK pass in native mode too.